### PR TITLE
Add step for creating load on test app

### DIFF
--- a/cmd/runtests/runner.go
+++ b/cmd/runtests/runner.go
@@ -106,7 +106,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 	// 8. Deploy helloworld
 	fmt.Printf("\nStep 8 - Deploy helloworld\n")
-	_, err = uat.Test08DeployHelloworld(kubeconfigPath, clusterOneAPIEndpoint)
+	_, err = uat.Test08DeployTestApp(kubeconfigPath, clusterOneAPIEndpoint)
 	cliutil.ExitIfError(err)
 
 	//20. Delete cluster one.

--- a/cmd/runtests/runner.go
+++ b/cmd/runtests/runner.go
@@ -83,6 +83,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		clusterOneAPIEndpoint = result.Payload.APIEndpoint
 	}
 
+	// We wait after cluster creation, otherwise fetching cluster details frequently fails.
 	time.Sleep(3 * time.Second)
 
 	// 2. Create a node pool based on defaults.
@@ -105,9 +106,13 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	cliutil.ExitIfError(err)
 
 	// 8. Deploy helloworld
-	fmt.Printf("\nStep 8 - Deploy helloworld\n")
-	_, err = uat.Test08DeployTestApp(kubeconfigPath, clusterOneAPIEndpoint)
+	fmt.Printf("\nStep 8 - Deploy test app\n")
+	testAppURL, err := uat.Test08DeployTestApp(kubeconfigPath, clusterOneAPIEndpoint)
 	cliutil.ExitIfError(err)
+
+	// 9. Create load
+	fmt.Printf("\nStep 9 - Create load on test app\n")
+	uat.Test09CreateLoadOnIngress(testAppURL)
 
 	//20. Delete cluster one.
 	// fmt.Printf("\nStep 20 - Delete cluster\n")

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -1,0 +1,59 @@
+package load
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// ProduceLoad creates load on an endpoint.
+// It finishes when durationLimit or requestLimit is reached, whatever comes earlier.
+// Stats are logged to a file every 10 seconds.
+func ProduceLoad(endpointURL string, durationLimit time.Duration, requestLimit int) {
+	startTime := time.Now()
+	lastOutput := time.Now()
+	endTime := startTime.Add(durationLimit)
+
+	var successCount int64
+	var errorCount int64
+
+	f, err := os.OpenFile("load.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		log.Fatalf("error opening file: %v", err)
+	}
+	defer f.Close()
+	log.SetOutput(f)
+
+	for i := 0; i < requestLimit; i++ {
+		if time.Now().After(endTime) {
+			return
+		}
+
+		interval := time.Now().Sub(lastOutput)
+		if interval >= 10*time.Second {
+			numRequests := errorCount + successCount
+			duration := interval.Seconds() / float64(numRequests)
+			log.Printf("numRequests %d, successCount %d, errorCount %d, error rate: %.5f, average request duration: %.5f Sec", numRequests, successCount, errorCount, float64(errorCount)/float64(numRequests), duration)
+			successCount = 0
+			errorCount = 0
+			lastOutput = time.Now()
+		}
+
+		resp, err := http.Get(endpointURL)
+		if err != nil {
+			errorCount++
+			continue
+		}
+
+		defer resp.Body.Close()
+		_, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			errorCount++
+			continue
+		}
+
+		successCount++
+	}
+}

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -1,0 +1,19 @@
+package load
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_ProduceLoad(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`OK`))
+	}))
+	defer server.Close()
+
+	ProduceLoad(server.URL, 15*time.Second, 1_000_000_000)
+}

--- a/pkg/uat/uat.go
+++ b/pkg/uat/uat.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/giantswarm/node-pools-acceptance-test/pkg/cliutil"
 	"github.com/giantswarm/node-pools-acceptance-test/pkg/kubeconfig"
+	"github.com/giantswarm/node-pools-acceptance-test/pkg/load"
 	"github.com/giantswarm/node-pools-acceptance-test/pkg/shell"
 )
 
@@ -205,6 +206,7 @@ func Test07GetKubernetesNodes(kubeconfigPath string) error {
 }
 
 // Test08DeployTestApp attempts to deploy a helloworld app on the cluster.
+// Returns the ingress URL of the app.
 func Test08DeployTestApp(kubeconfigPath string, clusterAPIEndpoint string) (string, error) {
 	// cluster base domain based on API endpoint
 	clusterBaseDomain := strings.Replace(clusterAPIEndpoint, "https://api.", "", 1)

--- a/pkg/uat/uat.go
+++ b/pkg/uat/uat.go
@@ -251,6 +251,11 @@ func Test08DeployTestApp(kubeconfigPath string, clusterAPIEndpoint string) (stri
 	return endpoint, nil
 }
 
+// Test09CreateLoadOnIngress sets a constant load on the given URL.
+func Test09CreateLoadOnIngress(ingressEndpoint string) {
+	go load.ProduceLoad(ingressEndpoint, 3*time.Hour, 100_000_000)
+}
+
 // Test20ClusterDeletion tests whether a cluster gets deleted okay.
 func Test20ClusterDeletion(giantSwarmClient *gsclient.Gsclientgen, authWriter runtime.ClientAuthInfoWriter, clusterID string) error {
 	deleteClusterOneParams := clusters.NewDeleteClusterParams().WithClusterID(clusterID)

--- a/pkg/uat/uat.go
+++ b/pkg/uat/uat.go
@@ -228,7 +228,7 @@ func Test08DeployTestApp(kubeconfigPath string, clusterAPIEndpoint string) (stri
 		return "", microerror.Mask(err)
 	}
 
-	endpoint := "http://test." + clusterBaseDomain
+	endpoint := "http://test." + clusterBaseDomain + "/delay/1"
 
 	// Wait for the ingress to be reachable.
 	start := time.Now()


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6868

This PR adds

- In step 8, wait until the ingress is available. In case of an error, this takes up to 15 minutes (backoff default maximum) until the process quits with an error.
- step 9: create load on the test application. No checks are performed. Stats are logged into a file in the following format every 10 seconds:

```
2019/10/17 12:02:31 numRequests 20, successCount 20, errorCount 0, error rate: 0.00000, average request duration: 0.50241 Sec
```

In subsequent steps we will scale up the test app and see whether pods get scheduled where they should.
